### PR TITLE
Update the remote for the git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Contributions are welcome!
 
 To clone the repository and clone the Open Exoplanet Catalogye submodule following these steps
 
-    git clone git@github.com:hannorein/oec_plots.git
+    git clone https://github.com/OpenExoplanetCatalogue/oec_plots.git
     cd oec_plots
     git submodule init
     git submodule update


### PR DESCRIPTION
The existing git clone works fine but it causes problems if you use external
tools like [hub](https://hub.github.com/) as they do not get repo alias.
